### PR TITLE
chore: set lxml version to supported

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cssselect>=0.9.2
 feedfinder2>=0.0.4
 feedparser>=5.2.1
 jieba3k>=0.35.1
-lxml>=3.6.0
+lxml==5.1.0 # https://lxml.de/5.2/changes-5.2.0.html
 nltk>=3.2.1
 Pillow>=3.3.0
 pythainlp>=1.7.2


### PR DESCRIPTION
New lxml version (5.2.0) breaks import
```
E   ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
E   Install lxml[html_clean] or lxml_html_clean directly.
```
Probably easiest fix, but not sure if best one in longer run. 

https://lxml.de/5.2/changes-5.2.0.html
https://github.com/adbar/trafilatura/issues/532#issuecomment-2029767350